### PR TITLE
Add DialectsPostType

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -54,6 +54,8 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		return nil, "disallowing mention of demo plugin user"
 	}
 
+	post.Type = "custom_dialects_post"
+
 	// Otherwise, allow the post through.
 	return post, ""
 }

--- a/webapp/src/components/dialects_post_type.jsx
+++ b/webapp/src/components/dialects_post_type.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const {formatText, messageHtmlToComponent} = window.PostUtils;
+
+export default class PostType extends React.PureComponent {
+    static propTypes = {
+        post: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
+    }
+
+    render() {
+        const post = {...this.props.post};
+        const message = post.message + '...' || '';
+
+        const formattedText = messageHtmlToComponent(formatText(message));
+
+        return (
+            <div>
+                {formattedText}
+            </div>
+        );
+    }
+}

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -8,6 +8,7 @@ import LeftSidebarHeader from './components/left_sidebar_header';
 import UserAttributes from './components/user_attributes';
 import UserActions from './components/user_actions';
 import PostType from './components/post_type';
+import DialectsPostType from './components/dialects_post_type';
 import {
     MainMenuMobileIcon,
     ChannelHeaderButtonIcon,
@@ -40,6 +41,7 @@ export default class DemoPlugin {
         );
 
         registry.registerPostTypeComponent('custom_demo_plugin', PostType);
+        registry.registerPostTypeComponent('custom_dialects_post', DialectsPostType);
 
         registry.registerMainMenuAction(
             'Demo Plugin',


### PR DESCRIPTION
- Add a type of Post (Posts.Type in the database), `custom_dialects_posts`, and define its Redux Component 
- Force to set `custom_dialects_posts` in a server side hook, `MessageWillBePosted` in Go plugin
- Type anything in any channel
- Then, MM shows a customised design (this time, "message + ...") for a post type, `custom_dialects_posts`